### PR TITLE
fix open readonly encrypted database

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/database/sqlite/SQLite/Database.java
+++ b/android/src/main/java/com/getcapacitor/community/database/sqlite/SQLite/Database.java
@@ -171,7 +171,7 @@ public class Database {
             if (!isNCDB() && !this._readOnly) {
                 _db = SQLiteDatabase.openOrCreateDatabase(_file, password, null);
             } else {
-                _db = SQLiteDatabase.openDatabase(String.valueOf(_file), "", null, SQLiteDatabase.OPEN_READONLY);
+                _db = SQLiteDatabase.openDatabase(String.valueOf(_file), password, null, SQLiteDatabase.OPEN_READONLY);
             }
             if (_db != null) {
                 if (_db.isOpen()) {


### PR DESCRIPTION
I'm trying create the read/write connection and the readonly connection with an encrypted database , and my code like this:

```typescript
const sqlite = new SQLiteConnection(CapacitorSQLite)
if (!(await sqlite.isDatabase('db')).result) {
  await sqlite.setEncryptionSecret('123456')
}

let connection: SQLiteDBConnection
if ((await sqlite.checkConnectionsConsistency()).result) {
  connection = await sqlite.retrieveConnection('db', false)
} else {
  connection = await sqlite.createConnection('db', true, 'secret', 0, false)
}
if (!(await connection.isDBOpen()).result) {
  await connection.open()
}

const readonlyConnection = await sqlite.createConnection('db', true, 'secret', 0, true)
await readonlyConnection.open() // Error
```

then I got this error:
![image](https://user-images.githubusercontent.com/27805633/211283035-f5a7e1c4-4f29-41fa-83fd-a0f7e8649fe6.png)

I guessed that maybe the problem was caused by passing an empty password to SQLiteDatabase.openDatabase function, so I passed the password in, as in line 172, and it worked.

Hopefully it's help.